### PR TITLE
Update to latest CS 162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [1.3.6] 2015-10-22
+### Added
+- Latest version of CS 162, Operating Systems and System Programming
+
 ## [1.2.6] 2015-10-19
 ### Added
 - Badge/Link to the Awesome list

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Courses | Duration | Effort
 Courses | Duration | Effort
 :-- | :--: | :--:
 [Operating System Engineering](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-828-operating-system-engineering-fall-2012/)| - | -
-[Operating Systems and System Programming](https://www.youtube.com/watch?v=XgQo4JkN4Bw&list=PL3289DD0D0F0CD4A3)| 10 weeks | 2-3 hours/week
+[Operating Systems and System Programming](https://www.youtube.com/view_play_list?p=-XXv-cvA_iBDyz-ba4yDskqMDY6A1w_c)| 10 weeks | 2-3 hours/week
 
 ### Computer Networks
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ The **only things** that you need to know are how to use **Git** and **GitHub**.
 
 ## Change Log
 
-**Curriculum Version**: `1.2.6`
+**Curriculum Version**: `1.3.6`
 
 To show **respect** to all of our students, we will keep a [CHANGELOG](CHANGELOG.md) file that contains all the alterations that our curriculum may suffer.
 


### PR DESCRIPTION
The latest publicly available iteration of CS 162 is Spring 2015, while the one displayed in the README is from 2010. This one goes through new and emerging trends such as IoT, Cloud Computing, Quantum Computing, which feed back well into the other courses here.

Also, according to an announcement on the Youtube playlist page, this will be the last iteration of the course whose lectures will be posted to Youtube, so this shouldn't change for a while.