### PR TITLE
Add new free and paid introductory computer science textbooks

### DIFF
--- a/extras/free-books.md
+++ b/extras/free-books.md
@@ -40,6 +40,7 @@
 Name | Author(s)
 :-- | :--:
 [Structure and Interpretation of Computer Programs](https://mitpress.mit.edu/sicp/full-text/book/book.html) | Hal Abelson, Jerry Sussman, Julie Sussman 
+[Introduction to Computing: Explorations in Language, Logic, and Machines](http://www.computingbook.org/) | David Evans
 
 ### Math (Mathematical Thinking)
 

--- a/extras/paid-books.md
+++ b/extras/paid-books.md
@@ -37,6 +37,10 @@
 
 ### Introduction to Computer Science
 
+Name | Author | ISBN
+:-- | :--: | :--:
+[Introduction to Computation and Programming Using Python](https://www.amazon.com/Introduction-Computation-Programming-Using-Python/dp/0262525003/) | John V. Guttag | 978-0262525008
+
 ### Math (Mathematical Thinking)
 
 ### Program Design


### PR DESCRIPTION
Added two new textbooks in extras section.

In `paid-book.md`, added *Introduction to Computation and Programming Using Python* by John Guttag, the textbook which accompanies MITx 6.00.1/2.

In `free-books.md`, added *Introduction to Computing* by David Evans, who presents Udacity's introductory computer science course.