### PR TITLE
Update Programming Languages course link

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Courses | Duration | Effort | Prerequisites | Discussion
 :-- | :--: | :--: | :--: | :--:
 [Systematic Program Design](coursepages/spd/README.md) | 13 weeks | 8-10 hours/week | none | chat: [part 1](https://discord.gg/RfqAmGJ) / [part 2](https://discord.gg/kczJzpm)
 [Class-based Program Design](https://course.ccs.neu.edu/cs2510sp22/index.html) | 13 weeks | 5-10 hours/week | Systematic Program Design, High School Math | [chat](https://discord.com/channels/744385009028431943/891411727294562314)
-[Programming Languages](https://courses.cs.washington.edu/courses/cse341/19au/#lectures) | 11 weeks | 4-8 hours/week | Systematic Program Design | [chat](https://discord.gg/8BkJtXN)
+[Programming Languages](https://courses.cs.washington.edu/courses/cse341/19sp/#lectures) | 11 weeks | 4-8 hours/week | Systematic Program Design | [chat](https://discord.gg/8BkJtXN)
 [Object-Oriented Design](https://course.ccs.neu.edu/cs3500f19/) | 13 weeks | 5-10 hours/week | Class Based Program Design | [chat](https://discord.com/channels/744385009028431943/891412022120579103)
 [Software Architecture](https://www.coursera.org/learn/software-architecture) | 4 weeks | 2-5 hours/week | Object Oriented Design | [chat](https://discord.com/channels/744385009028431943/891412169638432788)
 


### PR DESCRIPTION
## What does this PR do?
- Updated the Programming Languages course URL in `README.md` to a working alternative.

## New Link
- Old:   `https://courses.cs.washington.edu/courses/cse341/19au/#lectures`
- New: `https://courses.cs.washington.edu/courses/cse341/19sp/#lectures`

## Description
Fixes the broken link for the **Programming Languages** course (UW CSE341) in the Core Programming section. The 2019 Autumn course page at `https://courses.cs.washington.edu/courses/cse341/19au/#lectures` is no longer accessible without an university login credentials.

Closes #1385