### PR TITLE
Change game theory from coursera to roughgarden archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Courses | Duration | Effort | Prerequisites
 :-- | :--: | :--: | :--:
 [Theory of Computation](https://ocw.mit.edu/courses/18-404j-theory-of-computation-fall-2020/) ([alternative](https://www.youtube.com/playlist?list=PLEE7DF8F5E0203A56)) | 13 weeks | 10 hours/week | [Mathematics for Computer Science](https://openlearninglibrary.mit.edu/courses/course-v1:OCW+6.042J+2T2019/about), logic, algorithms
 [Computational Geometry](https://www.edx.org/learn/geometry/tsinghua-university-ji-suan-ji-he-computational-geometry) | 16 weeks | 8 hours/week | algorithms, C++
-[Game Theory](https://www.coursera.org/learn/game-theory-1) | 8 weeks | 3 hours/week | mathematical thinking, probability, calculus
+[Algorithmic Game Theory](https://timroughgarden.org/f13/f13.html) | 10 weeks | 12 hours/week | Core Theory
 
 ### Advanced Information Security
 


### PR DESCRIPTION
Resolves #1394 

I was not able to find an explicit hour estimate.  Stanford runs on a quarter system of 10 week quarters, there are 2.5 ish hours of lectures per week in addition to textbook readings, weekly exercises, and biweekly problem sets.  I think 12 hours/week is a reasonable amount, though perhaps an underestimate.