### PR TITLE
Reflect that Nand2Tetris lectures are not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Courses | Duration | Effort | Prerequisites | Discussion
 
 Courses | Duration | Effort | Additional Text / Assignments| Prerequisites | Discussion
 :-- | :--: | :--: | :--: | :--: | :--:
-[Build a Modern Computer from First Principles: From Nand to Tetris](https://www.coursera.org/learn/build-a-computer) ([alternative](https://www.nand2tetris.org/)) | 6 weeks | 7-13 hours/week | - | C-like programming language | [chat](https://discord.gg/vxB2DRV)
+[Build a Modern Computer from First Principles: From Nand to Tetris](coursepages/nand2tetris/README.md) | 6 weeks | 7-13 hours/week | - | C-like programming language | [chat](https://discord.gg/vxB2DRV)
 [Build a Modern Computer from First Principles: Nand to Tetris Part II](https://www.coursera.org/learn/nand2tetris2) | 6 weeks | 12-18 hours/week | - | one of [these programming languages](https://user-images.githubusercontent.com/2046800/35426340-f6ce6358-026a-11e8-8bbb-4e95ac36b1d7.png), From Nand to Tetris Part I | [chat](https://discord.gg/AsUXcPu)
 [Operating Systems: Three Easy Pieces](coursepages/ostep/README.md) | 10-12 weeks | 6-10 hours/week | - | Nand to Tetris Part II | [chat](https://discord.gg/wZNgpep)
 [Computer Networking: a Top-Down Approach](http://gaia.cs.umass.edu/kurose_ross/online_lectures.htm)| 8 weeks | 4–12 hours/week | [Wireshark Labs](http://gaia.cs.umass.edu/kurose_ross/wireshark.php) | algebra, probability, basic CS | [chat](https://discord.gg/MJ9YXyV)

--- a/coursepages/nand2tetris/README.md
+++ b/coursepages/nand2tetris/README.md
@@ -1,0 +1,18 @@
+# Nand 2 Tetris
+
+Nand 2 Tetris is frequently cited as one of the most valuable courses in the OSSU curriculum.
+
+Unfortunately, it is one of the courses whose videos are currently behind a Coursera paywall.
+
+Fortunately, the creators of the course have made a wide body of materials available to all learners on the [course website](https://www.nand2tetris.org/).
+
+- [Lecture slides](https://www.nand2tetris.org/course) for each project in the course.
+- Links for purchasing the [course textbook](https://www.nand2tetris.org/book) _The Elements of Computing Systems: Building a Modern Computer from First Principles_.
+- [Tools for building the course projects](https://www.nand2tetris.org/software), such as the course IDE.
+
+Other creators have also recorded lectures to complement the Nand 2 Tetris course materials:
+- [Professor Eugene Ch'ng](https://www.youtube.com/playlist?list=PLbx-k3N9Yr9-vSAQ4QBzI981sU_xc_zWM)
+- [Youtuber Journey To Master Programmer](https://www.youtube.com/playlist?list=PLsgiGiSsE6jZD7SSSDaggWDvMKz-v9dsM)
+- [Youtuber Tea Leaves](https://www.youtube.com/playlist?list=PLu6SHDdOToSevttS9gneVdjr9eHMhV50K) (Note: the playlist does not appear to be order sequentially)
+
+Learners are encouraged to search for online discussions of the course!


### PR DESCRIPTION
Building on @kevintprivett recognition that the Nand2Tetris videos are not available and there is little reason to believe they will become available. https://github.com/ossu/computer-science/pull/1398
